### PR TITLE
Added Support for Date Type in Metadata

### DIFF
--- a/beancount_plugins_metadata_spray/plugins/metadata_spray.py
+++ b/beancount_plugins_metadata_spray/plugins/metadata_spray.py
@@ -7,6 +7,7 @@ from beancount.core import data
 from beancount.core import account
 from beancount.core import getters
 from beancount.core.data import Custom
+from datetime import datetime
 
 __plugins__ = ('metadata_spray_entries',)
 
@@ -48,7 +49,14 @@ def metadata_spray(entry,
             elif replace_type == 'dont_overwrite':
                 continue
 
-        entry_meta[metadata_key] = metadata_dict[metadata_key]
+        value = metadata_dict[metadata_key]
+
+        try:
+            value = datetime.strptime(value, '%Y-%m-%d').date()
+        except ValueError:
+            pass
+
+        entry_meta[metadata_key] = value
 
     return entry_meta, errors
 


### PR DESCRIPTION
I needed to use a date type for the metadata. I tried passing in some datetime functions to the spray, but never got it to work pass the eval() function. So I just modified the code to try and convert to an ISO date and use it if successful. This probably means you can't use an ISO date as a string, but I assume that is the less common scenario. Maybe there is a better way to do this.

```
plugin "beancount_plugins_metadata_spray.plugins.metadata_spray" " {'sprays': [
          { 'spray_type': 'account_open',
            'replace_type': 'dont_overwrite',
            'pattern': 'Assets:.*',
            'metadata_dict': { 'cleared_before': '2019-08-07'}},
          { 'spray_type': 'account_open',
            'replace_type': 'dont_overwrite',
            'pattern': 'Liabilities:.*',
            'metadata_dict': { 'cleared_before': '2019-08-07'}},
          ]}"

```